### PR TITLE
Support Azure OpenAI type api key

### DIFF
--- a/caafe/caafe.py
+++ b/caafe/caafe.py
@@ -137,6 +137,7 @@ def generate_features(
             stop=["```end"],
             temperature=0.5,
             max_tokens=500,
+            engine=model,
         )
         code = completion["choices"][0]["message"]["content"]
         code = code.replace("```python", "").replace("```", "").replace("<end>", "")


### PR DESCRIPTION
Using Azure OpenAI type api key could be like:

```python
openai.api_type = "azure"
openai.api_base = "url-to-endpoint"
openai.api_version = "version_info"
openai.api_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
```

When using the Azure OpenAI key for `openai`, by setting `openai.api_type = "azure"`, we need an `engine` or `deployment_id` to create a `ChatCompletion`. The source can be found here: https://github.com/openai/openai-python/blob/main/openai/api_resources/abstract/engine_api_resource.py , on line 84. The minimal change required to support the Azure OpenAI type api key is to specify `engine` as equivalent to `model`. This has been tested and works in my environment.